### PR TITLE
feat(components): improve ModuleList and LabelList components look and feel

### DIFF
--- a/frontend/src/lib/components/Homepage/LabelList.svelte
+++ b/frontend/src/lib/components/Homepage/LabelList.svelte
@@ -14,8 +14,14 @@
     {#each labels as label}
       <div class="bg-surface rounded-md p-3">
         <div class="flex justify-between items-center">
-          <p>{label.name}</p>
-          <span class="text-grey text-sm">{label.count} modules</span>
+          <!-- We replace whitespaces with hypens in case a label is using whitespaces as separator
+          for its keywords -->
+          <a href="/labels/{label.name.replace(' ', '-')}"
+            >{label.name.replace(" ", "-")}</a
+          >
+          <span class="font-semibold text-grey text-sm"
+            >{label.count} modules</span
+          >
         </div>
       </div>
     {/each}

--- a/frontend/src/lib/components/Homepage/ModuleList.svelte
+++ b/frontend/src/lib/components/Homepage/ModuleList.svelte
@@ -4,6 +4,7 @@
     version?: string;
     downloads?: string;
     description: string;
+    labels: string[];
   }
 
   export let title: string;
@@ -11,18 +12,30 @@
 </script>
 
 <div class="p-6">
-  <h2 class="text-xl font-semibold mb-4">{title}</h2>
+  <h2 class="font-semibold text-xl mb-4">{title}</h2>
   {#each modules as module}
     <div class="bg-surface p-4 rounded-md mb-4 last:mb-0">
-      <div class="flex justify-between items-center pb-2">
-        <h3 class="font-medium">{module.name}</h3>
+      <div class="flex justify-between items-center mb-1">
+        <a href="/modules/{module.name}" class="font-medium">{module.name}</a>
         {#if module.downloads}
-          <span class="text-grey text-sm">{module.downloads}</span>
+          <span class="font-semibold text-grey text-sm">{module.downloads}</span
+          >
         {:else}
-          <span class="text-grey text-sm">{module.version}</span>
+          <span class="font-semibold text-grey text-sm">{module.version}</span>
         {/if}
       </div>
       <p class="text-grey text-sm truncate">{module.description}</p>
+      <div class="flex flex-row mt-4">
+        {#each module.labels as label}
+          <!-- We replace whitespaces with hypens in case a label is using whitespaces as separator
+          for its keywords -->
+          <a
+            href="/labels/{label.replace(' ', '-')}"
+            class="pr-3 last:pr-0 font-mono text-blue text-sm hover:underline"
+            >#{label.replace(" ", "-")}</a
+          >
+        {/each}
+      </div>
     </div>
   {/each}
 </div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -11,44 +11,52 @@
         version: "v9.1.1",
         description:
           "Modernity meets insane extensibility. The future of organizing your life in Neovim",
+        labels: ["neovim", "note-taking"],
       },
       {
         name: "rocks.nvim",
         version: "v2.40.0",
         description:
           "Neovim plugin management inspired by Cargo, powered by luarocks",
+        labels: ["neovim", "plugin manager"],
       },
       {
         name: "rest.nvim",
         version: "v3.6.0",
         description: "A fast Neovim http client written in Lua",
+        labels: ["neovim", "http", "rest"],
       },
       {
         name: "Imathx54",
         version: "v20240907",
         description: "C99 extensions for the math library",
+        labels: ["c", "math"],
       },
     ],
     downloaded: [
       {
         name: "lua-cjson",
         downloads: "20m",
-        description: "Fast JSON encoding/pansing support for Lua",
+        description: "Fast JSON encoding/parsing support for Lua",
+        labels: ["json", "encoding"],
       },
       {
         name: "LuaFileSystem",
         downloads: "8.7m",
         description: "File System Library for the Lua Programming Language",
+        labels: ["filesystem", "utilities"],
       },
       {
         name: "lua-resty-http",
         downloads: "6.7m",
         description: "Lua HTTP client cosocket driver for OpenResty/nglua",
+        labels: ["http", "driver", "openresty"],
       },
       {
         name: "LuaSQL-MYSQL",
         downloads: "6.3m",
         description: "Database connectivity for Lua (MySQL driver)",
+        labels: ["mysql", "driver", "databases"],
       },
     ],
   };


### PR DESCRIPTION
Changes made:
- Add labels to ModuleList cards.
- Make version and downloads count semi-bold in ModuleList cards.
- Make module names an href link to `/modules/foo`.
- Make modules count semi-bold in LabelList cards.

---

Previous cards look and feel:
![previous cards](https://github.com/user-attachments/assets/32f1c792-1e2d-4b86-9cc7-fc1dac591aba)

New cards look and feel:
![new cards](https://github.com/user-attachments/assets/abebfed4-efd1-4d40-b5ad-634753aea1e1)