### PR TITLE
ref: general styling fixes

### DIFF
--- a/lib/luanox_web/components/core_components.ex
+++ b/lib/luanox_web/components/core_components.ex
@@ -403,7 +403,7 @@ defmodule LuaNoxWeb.CoreComponents do
   attr :name, :atom, required: true
   attr :type, :atom, required: true, values: [:filled, :outline]
   attr :id, :string
-  attr :class, :string, default: "size-6"
+  attr :class, :string, default: "size-5"
 
   def icon(assigns) do
     name = assigns[:name]
@@ -516,7 +516,7 @@ defmodule LuaNoxWeb.CoreComponents do
     ~H"""
     <footer class="footer sm:footer-horizontal footer-center bg-base-300 text-base-content p-4">
       <aside>
-        <p>Copyright © {@copyright_year} - All rights reserved by {@org_name}</p>
+        <p>Copyright &copy; {@copyright_year} - All rights reserved by {@org_name}</p>
       </aside>
     </footer>
     """

--- a/lib/luanox_web/components/layouts.ex
+++ b/lib/luanox_web/components/layouts.ex
@@ -104,15 +104,15 @@ defmodule LuaNoxWeb.Layouts do
       <div class="absolute w-[33%] h-full rounded-md bg-base-300 brightness-150 dark:brightness-200 opacity-50 left-0 [[data-theme=light]_&]:left-[33.33%] [[data-theme=dark]_&]:left-[67%] transition-[left]" />
 
       <button phx-click={JS.dispatch("phx:set-theme", detail: %{theme: "system"})} class="p-2">
-        <.icon name={:device_desktop_cog} type={:outline} class="size-6 opacity-75 hover:opacity-100" />
+        <.icon name={:device_desktop_cog} type={:outline} class="size-5 opacity-75 hover:opacity-100" />
       </button>
 
       <button phx-click={JS.dispatch("phx:set-theme", detail: %{theme: "light"})} class="p-2">
-        <.icon name={:sun} type={:outline} class="size-6 opacity-75 hover:opacity-100" />
+        <.icon name={:sun} type={:outline} class="size-5 opacity-75 hover:opacity-100" />
       </button>
 
       <button phx-click={JS.dispatch("phx:set-theme", detail: %{theme: "dark"})} class="p-2">
-        <.icon name={:moon_stars} type={:outline} class="size-6 opacity-75 hover:opacity-100" />
+        <.icon name={:moon_stars} type={:outline} class="size-5 opacity-75 hover:opacity-100" />
       </button>
     </div>
 
@@ -122,19 +122,19 @@ defmodule LuaNoxWeb.Layouts do
           id="drop-system"
           name={:device_mobile_cog}
           type={:outline}
-          class="size-6 [[data-theme=light]_&]:hidden [[data-theme=dark]_&]:hidden"
+          class="size-5 [[data-theme=light]_&]:hidden [[data-theme=dark]_&]:hidden"
         />
         <.icon
           id="drop-light"
           name={:sun}
           type={:outline}
-          class="hidden [[data-theme=light]_&]:inline size-6"
+          class="hidden [[data-theme=light]_&]:inline size-5"
         />
         <.icon
           id="drop-dark"
           name={:moon_stars}
           type={:outline}
-          class="hidden [[data-theme=dark]_&]:inline size-6"
+          class="hidden [[data-theme=dark]_&]:inline size-5"
         />
       </div>
       <ul

--- a/lib/luanox_web/components/layouts/root.html.heex
+++ b/lib/luanox_web/components/layouts/root.html.heex
@@ -27,9 +27,9 @@
       })();
     </script>
   </head>
-  <body class="bg-base-100 antialiased md:subpixel-antialiased">
+  <body class="bg-base-100 antialiased md:subpixel-antialiased min-h-screen flex flex-col">
     <LuaNoxWeb.NavBar.navbar />
-    {@inner_content}
+    <main class="grow">{@inner_content}</main>
     <.footer />
   </body>
 </html>

--- a/lib/luanox_web/components/navbar.ex
+++ b/lib/luanox_web/components/navbar.ex
@@ -9,7 +9,7 @@ defmodule LuaNoxWeb.NavBar do
     <nav class="navbar bg-base-300 shadow-sm px-4 md:text-lg">
       <div class="navbar-start flex-1">
         <.link class="flex items-center text-2xl" navigate={~p"/"}>
-          <.logo class="h-8 md:h-10 w-auto md:mr-2" />
+          <.logo class="h-6 md:h-8 w-auto md:mr-2" />
           <span class="hidden md:inline font-semibold">Luanox</span>
         </.link>
       </div>
@@ -18,15 +18,15 @@ defmodule LuaNoxWeb.NavBar do
       <div class="flex items-center space-x-2 md:space-x-6">
         <LuaNoxWeb.Layouts.theme_toggle />
         <button
-          class="md:hidden btn btn-ghost text-lg rounded-field text-grey hover:text-base-content"
+          class="md:hidden btn btn-ghost rounded-field text-grey hover:text-base-content"
           phx-click={
             JS.toggle(to: "#mobile-menu")
             |> JS.toggle_class("hidden", to: "#menu-icon")
             |> JS.toggle_class("hidden", to: "#close-icon")
           }
         >
-          <.icon id="menu-icon" name={:menu_deep} type={:outline} class="size-6" />
-          <.icon id="close-icon" name={:x} type={:outline} class="hidden hover:text-error" />
+          <.icon id="menu-icon" name={:menu_deep} type={:outline} class="size-5" />
+          <.icon id="close-icon" name={:x} type={:outline} class="hidden hover:text-error size-5" />
         </button>
       </div>
 
@@ -43,10 +43,10 @@ defmodule LuaNoxWeb.NavBar do
       <div
         tabindex="0"
         role="button"
-        class="btn btn-ghost text-lg text-grey hover:text-info rounded-field"
+        class="btn btn-ghost text-grey hover:text-info rounded-field"
       >
         <.icon name={:square_plus} type={:outline} />
-        <span>Create</span>
+        <span class="mt-px">Create</span>
       </div>
       <ul
         tabindex="0"
@@ -79,10 +79,10 @@ defmodule LuaNoxWeb.NavBar do
       <div
         tabindex="0"
         role="button"
-        class="btn btn-ghost text-lg text-grey hover:text-info rounded-field"
+        class="btn btn-ghost text-grey hover:text-info rounded-field"
       >
         <.icon name={:user_circle} type={:outline} />
-        <span>Account</span>
+        <span class="mt-px">Account</span>
       </div>
       <ul
         tabindex="0"
@@ -105,9 +105,9 @@ defmodule LuaNoxWeb.NavBar do
     <div class="hidden md:flex items-center space-x-2">
       <ul class="menu menu-horizontal px-1 space-x-2">
         <li>
-          <.link class="btn btn-ghost text-lg text-grey hover:text-info" href="/docs">
+          <.link class="btn btn-ghost text-grey hover:text-info" href="/docs">
             <.icon name={:book_2} type={:outline} />
-            <span>Docs</span>
+            <span class="mt-px">Docs</span>
           </.link>
         </li>
         <.create_dropdown />
@@ -120,14 +120,16 @@ defmodule LuaNoxWeb.NavBar do
   defp mobile_menu(assigns) do
     ~H"""
     <div id="mobile-menu" class="hidden absolute top-16 left-0 w-full bg-base-300 rounded-b-md shadow-md flex flex-row items-center justify-between pt-2 pb-4 px-6 md:hidden z-10">
-      <ul class="menu menu-horizontal">
+      <ul class="menu menu-horizontal justify-between w-full">
         <li>
-          <.link class="btn btn-ghost text-lg text-grey hover:text-info" href="/docs">
+          <.link class="btn btn-ghost text-grey hover:text-info" href="/docs">
             <.icon name={:book_2} type={:outline} />
-              <span>Docs</span>
+              <span class="mt-px">Docs</span>
           </.link>
         </li>
+        <hr class="border-l border-dark-grey h-auto" />
         <.create_dropdown />
+        <hr class="border-l border-dark-grey h-auto" />
         <.account_dropdown />
       </ul>
     </div>

--- a/lib/luanox_web/components/package_box.ex
+++ b/lib/luanox_web/components/package_box.ex
@@ -7,15 +7,15 @@ defmodule LuaNoxWeb.PackageBox do
 
   def package(assigns) do
     ~H"""
-    <button class="btn btn-tertiary btn-block w-[15rem] h-[4rem]">
+    <button class="btn btn-tertiary btn-block rounded-md border border-dark-grey w-[15rem] h-[4rem] p-2">
       <div class="grid grid-rows-2 grid-cols-2 row-gap-5 w-full h-full">
         <h3 class="font-bold justify-self-start">
           {@name}
         </h3>
-        <h3 class="justify-self-end">
+        <h3 class="font-normal justify-self-end">
           {@version}
         </h3>
-        <p class="col-span-2">
+        <p class="font-normal col-span-2 justify-self-start">
           {@description}
         </p>
       </div>


### PR DESCRIPTION
- Improve PackageBox component styling
- Downscale navbar fonts and icons
- Make body a flexbox container so that we can easily send the footer to the very bottom of the viewport and resize the main content on the fly by using `grow`
- Enclose `@inner_content` in a `main` tag to keep the produced HTML semantic in the `root.html.heex` layout