### PR TITLE
feat: database storage for packages and releases

### DIFF
--- a/lib/luanox/accounts/scope.ex
+++ b/lib/luanox/accounts/scope.ex
@@ -16,6 +16,9 @@ defmodule LuaNox.Accounts.Scope do
   growing application requirements.
   """
 
+  alias LuaNox.Packages.Release
+  alias LuaNox.Repo
+  alias LuaNox.Packages.Package
   alias LuaNox.Accounts.User
 
   defstruct user: nil
@@ -30,4 +33,16 @@ defmodule LuaNox.Accounts.Scope do
   end
 
   def for_user(nil), do: nil
+
+  def for_package(%Package{} = package) do
+    %__MODULE__{user: Repo.preload(package, :user) |> Map.get(:user)}
+  end
+
+  def for_package(nil), do: nil
+
+  def for_release(%Release{} = release) do
+    %__MODULE__{user: for_package(Repo.preload(release, :package) |> Map.get(:package))}
+  end
+
+  def for_release(nil), do: nil
 end

--- a/lib/luanox/packages.ex
+++ b/lib/luanox/packages.ex
@@ -1,0 +1,240 @@
+defmodule LuaNox.Packages do
+  @moduledoc """
+  The Packages context.
+  """
+
+  import Ecto.Query, warn: false
+  alias LuaNox.Repo
+
+  alias LuaNox.Packages.Package
+  alias LuaNox.Accounts.Scope
+
+  @doc """
+  Subscribes to scoped notifications about any package changes.
+
+  The broadcasted messages match the pattern:
+
+    * {:created, %Package{}}
+    * {:updated, %Package{}}
+    * {:deleted, %Package{}}
+
+  """
+  def subscribe_packages(%Scope{} = scope) do
+    key = scope.user.id
+
+    Phoenix.PubSub.subscribe(LuaNox.PubSub, "user:#{key}:packages")
+  end
+
+  defp broadcast(%Scope{} = scope, message) do
+    key = scope.user.id
+
+    Phoenix.PubSub.broadcast(LuaNox.PubSub, "user:#{key}:packages", message)
+  end
+
+  @doc """
+  Returns the list of packages.
+
+  ## Examples
+
+      iex> list_packages(scope)
+      [%Package{}, ...]
+
+  """
+  def list_packages() do
+    Repo.all(Package) |> Repo.preload(:releases)
+  end
+
+  @doc """
+  Gets a single package.
+
+  Raises `Ecto.NoResultsError` if the Package does not exist.
+
+  ## Examples
+
+      iex> get_package!(123)
+      %Package{}
+
+      iex> get_package!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_package!(id) do
+    Repo.get_by!(Package, id: id)
+  end
+
+  @doc """
+  Creates a package.
+
+  ## Examples
+
+      iex> create_package(%{field: value})
+      {:ok, %Package{}}
+
+      iex> create_package(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_package(%Scope{} = scope, attrs) do
+    with {:ok, package = %Package{}} <-
+           %Package{}
+           |> Package.changeset(attrs, scope)
+           |> Repo.insert() do
+      broadcast(scope, {:created, package})
+      {:ok, package}
+    end
+  end
+
+  @doc """
+  Updates a package.
+
+  ## Examples
+
+      iex> update_package(package, %{field: new_value})
+      {:ok, %Package{}}
+
+      iex> update_package(package, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_package(
+        %Scope{} = scope,
+        %Package{} = package,
+        %{summary: _, description: _} = attrs
+      ) do
+    true = package.user_id == scope.user.id
+
+    with {:ok, package = %Package{}} <-
+           package
+           |> Package.changeset(attrs, scope)
+           |> Repo.update() do
+      broadcast(scope, {:updated, package})
+      {:ok, package}
+    end
+  end
+
+  @doc """
+  Deletes a package.
+
+  ## Examples
+
+      iex> delete_package(package)
+      {:ok, %Package{}}
+
+      iex> delete_package(package)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_package(%Scope{} = scope, %Package{} = package) do
+    true = package.user_id == scope.user.id
+
+    with {:ok, package = %Package{}} <-
+           Repo.delete(package) do
+      broadcast(scope, {:deleted, package})
+      {:ok, package}
+    end
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking package changes.
+
+  ## Examples
+
+      iex> change_package(package)
+      %Ecto.Changeset{data: %Package{}}
+
+  """
+  def change_package(%Scope{} = scope, %Package{} = package, attrs \\ %{}) do
+    true = package.user_id == scope.user.id
+
+    Package.changeset(package, attrs, scope)
+  end
+
+  alias LuaNox.Packages.Release
+
+  @doc """
+  Subscribes to scoped notifications about any release changes.
+
+  The broadcasted messages match the pattern:
+
+    * {:created, %Release{}}
+    * {:updated, %Release{}}
+    * {:deleted, %Release{}}
+
+  """
+  def subscribe_releases(%Scope{} = scope) do
+    key = scope.user.id
+
+    Phoenix.PubSub.subscribe(LuaNox.PubSub, "user:#{key}:releases")
+  end
+
+  @doc """
+  Returns the list of releases.
+
+  ## Examples
+
+      iex> list_releases(scope)
+      [%Release{}, ...]
+
+  """
+  def list_releases(%Package{} = package) do
+    Repo.get(Package, package)
+    |> Repo.preload(:releases)
+    |> Map.get(:releases)
+  end
+
+  @doc """
+  Gets a single release.
+
+  Raises `Ecto.NoResultsError` if the Release does not exist.
+
+  ## Examples
+
+      iex> get_release!(123)
+      %Release{}
+
+      iex> get_release!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_release!(id) do
+    Repo.get_by!(Release, id: id)
+  end
+
+  @doc """
+  Creates a release.
+  """
+  def add_release(%Scope{} = scope, %Package{} = package, attrs) do
+    with {:ok, release} <-
+           package
+           |> Ecto.build_assoc(:releases)
+           |> Release.changeset(attrs)
+           |> Repo.insert() do
+      broadcast(scope, {:created, release})
+      {:ok, release}
+    end
+  end
+
+  @doc """
+  Deletes a release.
+
+  ## Examples
+
+      iex> delete_release(release)
+      {:ok, %Release{}}
+
+      iex> delete_release(release)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_release(%Scope{} = scope, %Release{} = release) do
+    release_scope = Scope.for_release(release)
+
+    true = release_scope == scope
+
+    with {:ok, release = %Release{}} <-
+           Repo.delete(release) do
+      broadcast(scope, {:deleted, release})
+      {:ok, release}
+    end
+  end
+end

--- a/lib/luanox/packages/package.ex
+++ b/lib/luanox/packages/package.ex
@@ -1,0 +1,29 @@
+defmodule LuaNox.Packages.Package do
+  alias LuaNox.Accounts.Scope
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "packages" do
+    field :name, :string
+    field :summary, :string
+    field :description, :string
+    belongs_to :user, LuaNox.Accounts.User
+    has_many :releases, LuaNox.Packages.Release
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(package, attrs, %Scope{} = user_scope) do
+    package
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> unique_constraint(:name)
+    # Recast here to prevent the user from changing the package name
+    |> cast(attrs, [:summary, :description])
+    |> validate_length(:name, min: 1, max: 20)
+    |> validate_length(:summary, min: 1, max: 100)
+    |> validate_length(:description, max: 9999)
+    |> put_change(:user_id, user_scope.user.id)
+  end
+end

--- a/lib/luanox/packages/release.ex
+++ b/lib/luanox/packages/release.ex
@@ -1,0 +1,21 @@
+defmodule LuaNox.Packages.Release do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "releases" do
+    field :version, :string
+    field :rockspec, :string
+    belongs_to :package, LuaNox.Packages.Package
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(release, attrs) do
+    # TODO: In the future verify that the rockspec is valid
+    release
+    |> cast(attrs, [:version, :rockspec])
+    |> validate_required([:version, :rockspec])
+    |> validate_format(:version, ~r/^\d+(\.\d+){2}$/)
+  end
+end

--- a/lib/luanox_web/controllers/changeset_json.ex
+++ b/lib/luanox_web/controllers/changeset_json.ex
@@ -1,0 +1,25 @@
+defmodule LuaNoxWeb.ChangesetJSON do
+  @doc """
+  Renders changeset errors.
+  """
+  def error(%{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: Ecto.Changeset.traverse_errors(changeset, &translate_error/1)}
+  end
+
+  defp translate_error({msg, opts}) do
+    # You can make use of gettext to translate error messages by
+    # uncommenting and adjusting the following code:
+
+    # if count = opts[:count] do
+    #   Gettext.dngettext(LuaNoxWeb.Gettext, "errors", msg, msg, count, opts)
+    # else
+    #   Gettext.dgettext(LuaNoxWeb.Gettext, "errors", msg, opts)
+    # end
+
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end
+end

--- a/lib/luanox_web/controllers/fallback_controller.ex
+++ b/lib/luanox_web/controllers/fallback_controller.ex
@@ -1,0 +1,24 @@
+defmodule LuaNoxWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use LuaNoxWeb, :controller
+
+  # This clause handles errors returned by Ecto's insert/update/delete.
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: LuaNoxWeb.ChangesetJSON)
+    |> render(:error, changeset: changeset)
+  end
+
+  # This clause is an example of how to handle resources that cannot be found.
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(html: LuaNoxWeb.ErrorHTML, json: LuaNoxWeb.ErrorJSON)
+    |> render(:"404")
+  end
+end

--- a/lib/luanox_web/controllers/package_controller.ex
+++ b/lib/luanox_web/controllers/package_controller.ex
@@ -1,0 +1,43 @@
+defmodule LuaNoxWeb.PackageController do
+  use LuaNoxWeb, :controller
+
+  alias LuaNox.Packages
+  alias LuaNox.Packages.Package
+
+  action_fallback LuaNoxWeb.FallbackController
+
+  def index(conn, _params) do
+    packages = Packages.list_packages(conn.assigns.current_scope)
+    render(conn, :index, packages: packages)
+  end
+
+  def create(conn, %{"package" => package_params}) do
+    with {:ok, %Package{} = package} <- Packages.create_package(conn.assigns.current_scope, package_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", ~p"/api/packages/#{package}")
+      |> render(:show, package: package)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    package = Packages.get_package!(conn.assigns.current_scope, id)
+    render(conn, :show, package: package)
+  end
+
+  def update(conn, %{"id" => id, "package" => package_params}) do
+    package = Packages.get_package!(conn.assigns.current_scope, id)
+
+    with {:ok, %Package{} = package} <- Packages.update_package(conn.assigns.current_scope, package, package_params) do
+      render(conn, :show, package: package)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    package = Packages.get_package!(conn.assigns.current_scope, id)
+
+    with {:ok, %Package{}} <- Packages.delete_package(conn.assigns.current_scope, package) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/luanox_web/controllers/package_json.ex
+++ b/lib/luanox_web/controllers/package_json.ex
@@ -1,0 +1,24 @@
+defmodule LuaNoxWeb.PackageJSON do
+  alias LuaNox.Packages.Package
+
+  @doc """
+  Renders a list of packages.
+  """
+  def index(%{packages: packages}) do
+    %{data: for(package <- packages, do: data(package))}
+  end
+
+  @doc """
+  Renders a single package.
+  """
+  def show(%{package: package}) do
+    %{data: data(package)}
+  end
+
+  defp data(%Package{} = package) do
+    %{
+      id: package.id,
+      name: package.name
+    }
+  end
+end

--- a/lib/luanox_web/controllers/release_controller.ex
+++ b/lib/luanox_web/controllers/release_controller.ex
@@ -1,0 +1,43 @@
+defmodule LuaNoxWeb.ReleaseController do
+  use LuaNoxWeb, :controller
+
+  alias LuaNox.Packages
+  alias LuaNox.Packages.Release
+
+  action_fallback LuaNoxWeb.FallbackController
+
+  def index(conn, _params) do
+    releases = Packages.list_releases(conn.assigns.current_scope)
+    render(conn, :index, releases: releases)
+  end
+
+  def create(conn, %{"release" => release_params}) do
+    with {:ok, %Release{} = release} <- Packages.create_release(conn.assigns.current_scope, release_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", ~p"/api/releases/#{release}")
+      |> render(:show, release: release)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    release = Packages.get_release!(conn.assigns.current_scope, id)
+    render(conn, :show, release: release)
+  end
+
+  def update(conn, %{"id" => id, "release" => release_params}) do
+    release = Packages.get_release!(conn.assigns.current_scope, id)
+
+    with {:ok, %Release{} = release} <- Packages.update_release(conn.assigns.current_scope, release, release_params) do
+      render(conn, :show, release: release)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    release = Packages.get_release!(conn.assigns.current_scope, id)
+
+    with {:ok, %Release{}} <- Packages.delete_release(conn.assigns.current_scope, release) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/luanox_web/controllers/release_json.ex
+++ b/lib/luanox_web/controllers/release_json.ex
@@ -1,0 +1,25 @@
+defmodule LuaNoxWeb.ReleaseJSON do
+  alias LuaNox.Packages.Release
+
+  @doc """
+  Renders a list of releases.
+  """
+  def index(%{releases: releases}) do
+    %{data: for(release <- releases, do: data(release))}
+  end
+
+  @doc """
+  Renders a single release.
+  """
+  def show(%{release: release}) do
+    %{data: data(release)}
+  end
+
+  defp data(%Release{} = release) do
+    %{
+      id: release.id,
+      version: release.version,
+      rockspec: release.rockspec
+    }
+  end
+end

--- a/lib/luanox_web/live/page_live.ex
+++ b/lib/luanox_web/live/page_live.ex
@@ -1,4 +1,5 @@
 defmodule LuaNoxWeb.PageLive do
+  alias LuaNox.Packages
   use LuaNoxWeb, :live_view
 
   import LuaNoxWeb.PackageBox
@@ -6,8 +7,6 @@ defmodule LuaNoxWeb.PageLive do
   def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign(:packages, [
-       %{name: "luanox", description: "A Lua package manager", version: "0.1.0"}
-     ])}
+     |> assign(:packages, Packages.list_packages())}
   end
 end

--- a/lib/luanox_web/live/page_live.html.heex
+++ b/lib/luanox_web/live/page_live.html.heex
@@ -34,8 +34,8 @@
   <div class="flex flex-col items-center justify-center py-4">
     <%!-- <h2 class="text-2xl font-bold mb-4">Featured Packages</h2> --%>
     <div class="flex gap-4 max-w-screen-lg">
-      <%= for %{name: name, version: version, description: description} <- @packages do %>
-        <.package name={name} version={version} description={description} />
+      <%= for %{name: name, summary: summary, releases: releases} <- @packages do %>
+        <.package name={name} version={List.last(releases).version || ""} description={summary} />
       <% end %>
     </div>
   </div>

--- a/lib/luanox_web/router.ex
+++ b/lib/luanox_web/router.ex
@@ -15,6 +15,7 @@ defmodule LuaNoxWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug :fetch_current_scope_for_user
   end
 
   scope "/", LuaNoxWeb do
@@ -45,6 +46,8 @@ defmodule LuaNoxWeb.Router do
   # Other scopes may use custom stacks.
   scope "/api", LuaNoxWeb do
     pipe_through :api
+
+    resources "/packages", PackageController, except: [:edit]
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/priv/repo/migrations/20250517194920_create_packages.exs
+++ b/priv/repo/migrations/20250517194920_create_packages.exs
@@ -1,0 +1,17 @@
+defmodule LuaNox.Repo.Migrations.CreatePackages do
+  use Ecto.Migration
+
+  def change do
+    create table(:packages) do
+      add :name, :string, null: false
+      add :summary, :string
+      add :description, :string
+      add :user_id, references(:users, type: :id, on_delete: :delete_all)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:packages, [:name])
+    create index(:packages, [:user_id])
+  end
+end

--- a/priv/repo/migrations/20250517195054_create_releases.exs
+++ b/priv/repo/migrations/20250517195054_create_releases.exs
@@ -1,0 +1,15 @@
+defmodule LuaNox.Repo.Migrations.CreateReleases do
+  use Ecto.Migration
+
+  def change do
+    create table(:releases) do
+      add :version, :string
+      add :rockspec, :string
+      add :package_id, references(:packages, on_delete: :nothing)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:releases, [:package_id])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,59 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias LuaNox.Packages.Release
+alias LuaNox.Accounts.User
+alias LuaNox.Repo
+alias LuaNox.Packages.Package
+
+Repo.delete_all(Release)
+Repo.delete_all(Package)
+Repo.delete_all(User)
+
+Repo.insert!(%User{
+  id: 1,
+  email: "admin@example.com",
+  provider: "github",
+  username: "admin",
+  aka: "admin"
+})
+
+Repo.insert!(%Package{
+  id: 1,
+  name: "luanox",
+  summary: "An epic Lua site",
+  description: "Full description of the package",
+  user_id: 1
+})
+
+Repo.insert!(%Release{
+  id: 1,
+  version: "1.0.0",
+  rockspec: "<content>",
+  package_id: 1
+})
+
+Repo.insert!(%Release{
+  id: 2,
+  version: "1.0.1",
+  rockspec: "<content>",
+  package_id: 1
+})
+
+# ------------------------------------------------
+
+Repo.insert!(%Package{
+  id: 2,
+  name: "luarocks",
+  summary: "The other epic Lua site",
+  description: "Full description of the package",
+  user_id: 1
+})
+
+Repo.insert!(%Release{
+  id: 3,
+  version: "0.2.0",
+  rockspec: "<content>",
+  package_id: 2
+})

--- a/test/luanox/packages_test.exs
+++ b/test/luanox/packages_test.exs
@@ -1,0 +1,179 @@
+defmodule LuaNox.PackagesTest do
+  use LuaNox.DataCase
+
+  alias LuaNox.Packages
+
+  describe "packages" do
+    alias LuaNox.Packages.Package
+
+    import LuaNox.AccountsFixtures, only: [user_scope_fixture: 0]
+    import LuaNox.PackagesFixtures
+
+    @invalid_attrs %{name: nil}
+
+    test "list_packages/1 returns all scoped packages" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      package = package_fixture(scope)
+      other_package = package_fixture(other_scope)
+      assert Packages.list_packages(scope) == [package]
+      assert Packages.list_packages(other_scope) == [other_package]
+    end
+
+    test "get_package!/2 returns the package with given id" do
+      scope = user_scope_fixture()
+      package = package_fixture(scope)
+      other_scope = user_scope_fixture()
+      assert Packages.get_package!(scope, package.id) == package
+      assert_raise Ecto.NoResultsError, fn -> Packages.get_package!(other_scope, package.id) end
+    end
+
+    test "create_package/2 with valid data creates a package" do
+      valid_attrs = %{name: "some name"}
+      scope = user_scope_fixture()
+
+      assert {:ok, %Package{} = package} = Packages.create_package(scope, valid_attrs)
+      assert package.name == "some name"
+      assert package.user_id == scope.user.id
+    end
+
+    test "create_package/2 with invalid data returns error changeset" do
+      scope = user_scope_fixture()
+      assert {:error, %Ecto.Changeset{}} = Packages.create_package(scope, @invalid_attrs)
+    end
+
+    test "update_package/3 with valid data updates the package" do
+      scope = user_scope_fixture()
+      package = package_fixture(scope)
+      update_attrs = %{name: "some updated name"}
+
+      assert {:ok, %Package{} = package} = Packages.update_package(scope, package, update_attrs)
+      assert package.name == "some updated name"
+    end
+
+    test "update_package/3 with invalid scope raises" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      package = package_fixture(scope)
+
+      assert_raise MatchError, fn ->
+        Packages.update_package(other_scope, package, %{})
+      end
+    end
+
+    test "update_package/3 with invalid data returns error changeset" do
+      scope = user_scope_fixture()
+      package = package_fixture(scope)
+      assert {:error, %Ecto.Changeset{}} = Packages.update_package(scope, package, @invalid_attrs)
+      assert package == Packages.get_package!(scope, package.id)
+    end
+
+    test "delete_package/2 deletes the package" do
+      scope = user_scope_fixture()
+      package = package_fixture(scope)
+      assert {:ok, %Package{}} = Packages.delete_package(scope, package)
+      assert_raise Ecto.NoResultsError, fn -> Packages.get_package!(scope, package.id) end
+    end
+
+    test "delete_package/2 with invalid scope raises" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      package = package_fixture(scope)
+      assert_raise MatchError, fn -> Packages.delete_package(other_scope, package) end
+    end
+
+    test "change_package/2 returns a package changeset" do
+      scope = user_scope_fixture()
+      package = package_fixture(scope)
+      assert %Ecto.Changeset{} = Packages.change_package(scope, package)
+    end
+  end
+
+  describe "releases" do
+    alias LuaNox.Packages.Release
+
+    import LuaNox.AccountsFixtures, only: [user_scope_fixture: 0]
+    import LuaNox.PackagesFixtures
+
+    @invalid_attrs %{version: nil, rockspec: nil}
+
+    test "list_releases/1 returns all scoped releases" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      release = release_fixture(scope)
+      other_release = release_fixture(other_scope)
+      assert Packages.list_releases(scope) == [release]
+      assert Packages.list_releases(other_scope) == [other_release]
+    end
+
+    test "get_release!/2 returns the release with given id" do
+      scope = user_scope_fixture()
+      release = release_fixture(scope)
+      other_scope = user_scope_fixture()
+      assert Packages.get_release!(scope, release.id) == release
+      assert_raise Ecto.NoResultsError, fn -> Packages.get_release!(other_scope, release.id) end
+    end
+
+    test "create_release/2 with valid data creates a release" do
+      valid_attrs = %{version: "some version", rockspec: "some rockspec"}
+      scope = user_scope_fixture()
+
+      assert {:ok, %Release{} = release} = Packages.create_release(scope, valid_attrs)
+      assert release.version == "some version"
+      assert release.rockspec == "some rockspec"
+      assert release.user_id == scope.user.id
+    end
+
+    test "create_release/2 with invalid data returns error changeset" do
+      scope = user_scope_fixture()
+      assert {:error, %Ecto.Changeset{}} = Packages.create_release(scope, @invalid_attrs)
+    end
+
+    test "update_release/3 with valid data updates the release" do
+      scope = user_scope_fixture()
+      release = release_fixture(scope)
+      update_attrs = %{version: "some updated version", rockspec: "some updated rockspec"}
+
+      assert {:ok, %Release{} = release} = Packages.update_release(scope, release, update_attrs)
+      assert release.version == "some updated version"
+      assert release.rockspec == "some updated rockspec"
+    end
+
+    test "update_release/3 with invalid scope raises" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      release = release_fixture(scope)
+
+      assert_raise MatchError, fn ->
+        Packages.update_release(other_scope, release, %{})
+      end
+    end
+
+    test "update_release/3 with invalid data returns error changeset" do
+      scope = user_scope_fixture()
+      release = release_fixture(scope)
+      assert {:error, %Ecto.Changeset{}} = Packages.update_release(scope, release, @invalid_attrs)
+      assert release == Packages.get_release!(scope, release.id)
+    end
+
+    test "delete_release/2 deletes the release" do
+      scope = user_scope_fixture()
+      release = release_fixture(scope)
+      assert {:ok, %Release{}} = Packages.delete_release(scope, release)
+      assert_raise Ecto.NoResultsError, fn -> Packages.get_release!(scope, release.id) end
+    end
+
+    test "delete_release/2 with invalid scope raises" do
+      scope = user_scope_fixture()
+      other_scope = user_scope_fixture()
+      release = release_fixture(scope)
+      assert_raise MatchError, fn -> Packages.delete_release(other_scope, release) end
+    end
+
+    test "change_release/2 returns a release changeset" do
+      scope = user_scope_fixture()
+      release = release_fixture(scope)
+      assert %Ecto.Changeset{} = Packages.change_release(scope, release)
+    end
+  end
+end

--- a/test/luanox_web/controllers/package_controller_test.exs
+++ b/test/luanox_web/controllers/package_controller_test.exs
@@ -1,0 +1,86 @@
+defmodule LuaNoxWeb.PackageControllerTest do
+  use LuaNoxWeb.ConnCase
+
+  import LuaNox.PackagesFixtures
+  alias LuaNox.Packages.Package
+
+  @create_attrs %{
+    name: "some name"
+  }
+  @update_attrs %{
+    name: "some updated name"
+  }
+  @invalid_attrs %{name: nil}
+
+  setup :register_and_log_in_user
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all packages", %{conn: conn} do
+      conn = get(conn, ~p"/api/packages")
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create package" do
+    test "renders package when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/api/packages", package: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, ~p"/api/packages/#{id}")
+
+      assert %{
+               "id" => ^id,
+               "name" => "some name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, ~p"/api/packages", package: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update package" do
+    setup [:create_package]
+
+    test "renders package when data is valid", %{conn: conn, package: %Package{id: id} = package} do
+      conn = put(conn, ~p"/api/packages/#{package}", package: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, ~p"/api/packages/#{id}")
+
+      assert %{
+               "id" => ^id,
+               "name" => "some updated name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, package: package} do
+      conn = put(conn, ~p"/api/packages/#{package}", package: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete package" do
+    setup [:create_package]
+
+    test "deletes chosen package", %{conn: conn, package: package} do
+      conn = delete(conn, ~p"/api/packages/#{package}")
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, ~p"/api/packages/#{package}")
+      end
+    end
+  end
+
+  defp create_package(%{scope: scope}) do
+    package = package_fixture(scope)
+
+    %{package: package}
+  end
+end

--- a/test/luanox_web/controllers/release_controller_test.exs
+++ b/test/luanox_web/controllers/release_controller_test.exs
@@ -1,0 +1,90 @@
+defmodule LuaNoxWeb.ReleaseControllerTest do
+  use LuaNoxWeb.ConnCase
+
+  import LuaNox.PackagesFixtures
+  alias LuaNox.Packages.Release
+
+  @create_attrs %{
+    version: "some version",
+    rockspec: "some rockspec"
+  }
+  @update_attrs %{
+    version: "some updated version",
+    rockspec: "some updated rockspec"
+  }
+  @invalid_attrs %{version: nil, rockspec: nil}
+
+  setup :register_and_log_in_user
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all releases", %{conn: conn} do
+      conn = get(conn, ~p"/api/releases")
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create release" do
+    test "renders release when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/api/releases", release: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, ~p"/api/releases/#{id}")
+
+      assert %{
+               "id" => ^id,
+               "rockspec" => "some rockspec",
+               "version" => "some version"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, ~p"/api/releases", release: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update release" do
+    setup [:create_release]
+
+    test "renders release when data is valid", %{conn: conn, release: %Release{id: id} = release} do
+      conn = put(conn, ~p"/api/releases/#{release}", release: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, ~p"/api/releases/#{id}")
+
+      assert %{
+               "id" => ^id,
+               "rockspec" => "some updated rockspec",
+               "version" => "some updated version"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, release: release} do
+      conn = put(conn, ~p"/api/releases/#{release}", release: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete release" do
+    setup [:create_release]
+
+    test "deletes chosen release", %{conn: conn, release: release} do
+      conn = delete(conn, ~p"/api/releases/#{release}")
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, ~p"/api/releases/#{release}")
+      end
+    end
+  end
+
+  defp create_release(%{scope: scope}) do
+    release = release_fixture(scope)
+
+    %{release: release}
+  end
+end

--- a/test/support/fixtures/packages_fixtures.ex
+++ b/test/support/fixtures/packages_fixtures.ex
@@ -1,0 +1,33 @@
+defmodule LuaNox.PackagesFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `LuaNox.Packages` context.
+  """
+
+  @doc """
+  Generate a package.
+  """
+  def package_fixture(scope, attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        name: "some name"
+      })
+
+    {:ok, package} = LuaNox.Packages.create_package(scope, attrs)
+    package
+  end
+
+  @doc """
+  Generate a release.
+  """
+  def release_fixture(scope, attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        rockspec: "some rockspec",
+        version: "some version"
+      })
+
+    {:ok, release} = LuaNox.Packages.create_release(scope, attrs)
+    release
+  end
+end


### PR DESCRIPTION
Haven't tested every bit of functionality yet, but it all looks good so far. This updates the site to pull package data from the DB instead of from a predetermined list.