### PR TITLE
fix: oauth failure on some user accounts

### DIFF
--- a/luanox/lib/luanox/accounts/user.ex
+++ b/luanox/lib/luanox/accounts/user.ex
@@ -16,7 +16,7 @@ defmodule LuaNox.Accounts.User do
     timestamps(type: :utc_datetime)
   end
 
-  def unique_username(%LuaNox.Accounts.User{} = user), do: user.aka || user.username
+  def unique_username(%LuaNox.Accounts.User{} = user), do: user.username
 
   def oauth_changeset(user, %Auth{} = auth) do
     attrs = %{
@@ -32,7 +32,7 @@ defmodule LuaNox.Accounts.User do
     |> validate_required([:username])
     |> unique_constraint([:provider, :username])
     |> validate_provider()
-    |> validate_aka()
+    # |> validate_aka()
   end
 
   defp validate_provider(changeset) do


### PR DESCRIPTION
Caused by us assigning the nickname field to the `aka` which doesn't make sense because it's usually the person's name. We'll simply remiplement the aka system whenever we start adding support for more providers.