### PR TITLE
fix: relative path traversal vulnerability

### DIFF
--- a/luanox-rockspec-verifier/lib/luanox_rockspec_verifier/rockspec.ex
+++ b/luanox-rockspec-verifier/lib/luanox_rockspec_verifier/rockspec.ex
@@ -5,55 +5,57 @@ defmodule LuanoxRockspecVerifier.Rockspec do
       }) do
     sandboxed_state = :luerl_sandbox.init()
 
-    case :luerl_sandbox.run(
-           rockspec,
-           %{
-             max_reductions: 500
-             # max_time: ...
-           },
-           sandboxed_state
-         ) do
-      {:ok, _, state} ->
-        with {:ok, "3.0", _} <- Luerl.get_table_keys_dec(state, ["rockspec_format"]),
-             {:ok, ^expected_name, _} <-
-               Luerl.get_table_keys_dec(state, ["package"]),
-             {:ok, ^expected_version, _} <-
-               Luerl.get_table_keys_dec(state, ["version"]),
-             {:ok, source, _} <- Luerl.get_table_keys_dec(state, ["source"]),
-             {:ok, build, _} <- Luerl.get_table_keys_dec(state, ["build"]) do
-          {has_tag_or_hash, has_git_url} =
-            Enum.reduce(source, {false, false}, fn
-              {tag_or_hash, _}, {_, has_url} when tag_or_hash in ["tag", "hash"] ->
-                {true, has_url}
+    Regex.match?(~r/^[a-zA-Z0-9_\-]+$/, expected_name) and
+      case :luerl_sandbox.run(
+             rockspec,
+             %{
+               max_reductions: 500
+               # max_time: ...
+             },
+             sandboxed_state
+           ) do
+        {:ok, _, state} ->
+          with {:ok, %Version{}} <- Version.parse(expected_version),
+               {:ok, "3.0", _} <- Luerl.get_table_keys_dec(state, ["rockspec_format"]),
+               {:ok, ^expected_name, _} <-
+                 Luerl.get_table_keys_dec(state, ["package"]),
+               {:ok, ^expected_version, _} <-
+                 Luerl.get_table_keys_dec(state, ["version"]),
+               {:ok, source, _} <- Luerl.get_table_keys_dec(state, ["source"]),
+               {:ok, build, _} <- Luerl.get_table_keys_dec(state, ["build"]) do
+            {has_tag_or_hash, has_git_url} =
+              Enum.reduce(source, {false, false}, fn
+                {tag_or_hash, _}, {_, has_url} when tag_or_hash in ["tag", "hash"] ->
+                  {true, has_url}
 
-              {"url", "git+" <> _}, {has_tag, _} ->
-                {has_tag, true}
+                {"url", "git+" <> _}, {has_tag, _} ->
+                  {has_tag, true}
 
-              {"url", "git://" <> _}, {has_tag, _} ->
-                {has_tag, true}
+                {"url", "git://" <> _}, {has_tag, _} ->
+                  {has_tag, true}
 
-              _, acc ->
-                acc
-            end)
-
-          has_url =
-            has_git_url or
-              Enum.any?(source, fn
-                {"url", _} -> true
-                _ -> false
+                _, acc ->
+                  acc
               end)
 
-          ((has_tag_or_hash and has_git_url) or has_url) and
-            Enum.any?(build, fn
-              {"type", _} -> true
-              _ -> false
-            end)
-        else
-          _ -> false
-        end
+            has_url =
+              has_git_url or
+                Enum.any?(source, fn
+                  {"url", _} -> true
+                  _ -> false
+                end)
 
-      {:error, _} ->
-        false
-    end
+            ((has_tag_or_hash and has_git_url) or has_url) and
+              Enum.any?(build, fn
+                {"type", _} -> true
+                _ -> false
+              end)
+          else
+            _ -> false
+          end
+
+        {:error, _} ->
+          false
+      end
   end
 end

--- a/luanox/lib/luanox/packages/package.ex
+++ b/luanox/lib/luanox/packages/package.ex
@@ -32,6 +32,7 @@ defmodule LuaNox.Packages.Package do
     |> cast(attrs, [:name])
     |> validate_required([:name])
     |> unique_constraint(:name)
+    |> validate_format(:name, ~r/^[a-zA-Z0-9_\-]+$/)
     # Recast here to prevent the user from changing the package name
     |> cast(attrs, [:summary, :description])
     |> validate_length(:name, min: 1, max: 20)


### PR DESCRIPTION
I'll be publishing the security advisory soon! Original site allowed package names with relative paths (`../`). No data or site behaviour affected, vulnerability in best case can only DoS the server by overwriting some critical file with a lua rockspec.