### PR TITLE
fix: move lux hyperlink to static line

### DIFF
--- a/luanox/lib/luanox_web/live/page_live.html.heex
+++ b/luanox/lib/luanox_web/live/page_live.html.heex
@@ -57,14 +57,14 @@
                 A
                 <span id="typewriter" phx-hook="Typewriter" class="font-semibold text-secondary">
                 </span>
-                Lua module host for the
-                <a
-                  class="text-primary font-medium border-b border-primary/30 hover:border-primary"
-                  href="https://github.com/lumen-oss/lux"
-                >
-                  Lux
-                </a>
+                Lua module host 
               </span>
+              for the
+              <a
+                class="text-primary font-medium border-b border-primary/30 hover:border-primary"
+                href="https://github.com/lumen-oss/lux"
+              >
+                Lux</a>
               package manager, fully compatible with the <a
                 phx-no-format
                 class="text-primary font-medium border-b border-primary/30 hover:border-primary"


### PR DESCRIPTION
Fixes #73.

<img width="840" height="342" alt="scrot" src="https://github.com/user-attachments/assets/55222837-05aa-4179-b4c9-f6092d53940f" />
