### PR TITLE
feat(home): make hero banner stay on top of the actions in mobile

### DIFF
--- a/luanox/lib/luanox_web/live/page_live.html.heex
+++ b/luanox/lib/luanox_web/live/page_live.html.heex
@@ -1,7 +1,7 @@
 <Layouts.app flash={@flash} current_scope={@current_scope}>
   <!-- Hero Section -->
   <div class="min-h-[60vh] bg-base-100 flex items-center">
-    <div class="flex flex-col lg:flex-row-reverse lg:items-center max-w-6xl mx-auto px-4 lg:px-8 py-8 lg:py-16 w-full gap-8 lg:gap-16">
+    <div class="flex flex-col-reverse lg:flex-row-reverse lg:items-center max-w-6xl mx-auto px-4 lg:px-8 py-8 lg:py-16 w-full gap-8 lg:gap-16">
       <!-- Right Side - Actions -->
       <div class="flex-1 lg:max-w-md">
         <div class="bg-base-200 border border-base-300 p-6 lg:p-8 shadow-sm">


### PR DESCRIPTION
Stacked on top of #86

<details>
	<summary>Screenshot</summary>
	<img width="412" height="915" alt="image" src="https://github.com/user-attachments/assets/4ab010ab-8c8d-4eed-83a5-dcd498ea3857" />
</details>
