### PR TITLE
fix(navbar): properly call `/logout` endpoint

### DIFF
--- a/luanox/lib/luanox_web/components/navbar.ex
+++ b/luanox/lib/luanox_web/components/navbar.ex
@@ -72,7 +72,7 @@ defmodule LuaNoxWeb.NavBar do
         </li>
         <hr class="text-base-300 mt-1 mb-1" />
         <li>
-          <.link navigate={~p"/logout"} method="delete">Log out</.link>
+          <.link href={~p"/logout"} method="delete">Log out</.link>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
As the documentation for the link component in Phoenix states, `navigate` and `method` cannot be used together. Using `href` with `method` is the right way to call our logout endpoint with `DELETE`, as `href` will also force a full page reload on logout and thus clearing all client-side state which is our desired behavior.

See: https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#link/1