### PR TITLE
Fix version interpolation and store GitHub avatar URL

### DIFF
--- a/luanox/lib/luanox/accounts.ex
+++ b/luanox/lib/luanox/accounts.ex
@@ -92,6 +92,17 @@ defmodule LuaNox.Accounts do
     |> Repo.insert()
   end
 
+## Settings
+
+  @doc """
+  Updates the user's avatar URL, e.g. from a fresh OAuth login.
+  """
+  def update_user_avatar(%User{} = user, avatar_url) when is_binary(avatar_url) do
+    user
+    |> Ecto.Changeset.change(%{avatar_url: avatar_url})
+    |> Repo.update()
+  end
+
   ## Settings
 
   @doc """

--- a/luanox/lib/luanox/accounts.ex
+++ b/luanox/lib/luanox/accounts.ex
@@ -100,6 +100,7 @@ defmodule LuaNox.Accounts do
   def update_user_avatar(%User{} = user, avatar_url) when is_binary(avatar_url) do
     user
     |> Ecto.Changeset.change(%{avatar_url: avatar_url})
+    |> User.validate_avatar_url()
     |> Repo.update()
   end
 

--- a/luanox/lib/luanox/accounts/user.ex
+++ b/luanox/lib/luanox/accounts/user.ex
@@ -12,6 +12,7 @@ defmodule LuaNox.Accounts.User do
     field :provider, :string
     field :username, :string
     field :aka, :string
+    field :avatar_url, :string
 
     timestamps(type: :utc_datetime)
   end
@@ -23,12 +24,13 @@ defmodule LuaNox.Accounts.User do
       provider: to_string(auth.provider),
       # TODO: Github does this for some reason. We must test if gitlab does this too
       username: auth.info.nickname,
-      aka: auth.info.name
+      aka: auth.info.name,
+      avatar_url: auth.info.image
     }
 
     user
     |> email_changeset(%{email: auth.info.email})
-    |> cast(attrs, [:provider, :username, :aka])
+    |> cast(attrs, [:provider, :username, :aka, :avatar_url])
     |> validate_required([:username])
     |> unique_constraint([:provider, :username])
     |> validate_provider()

--- a/luanox/lib/luanox/accounts/user.ex
+++ b/luanox/lib/luanox/accounts/user.ex
@@ -17,6 +17,8 @@ defmodule LuaNox.Accounts.User do
     timestamps(type: :utc_datetime)
   end
 
+  @trusted_avatar_hosts ~w(avatars.githubusercontent.com)
+
   def unique_username(%LuaNox.Accounts.User{} = user), do: user.username
 
   def oauth_changeset(user, %Auth{} = auth) do
@@ -34,7 +36,7 @@ defmodule LuaNox.Accounts.User do
     |> validate_required([:username])
     |> unique_constraint([:provider, :username])
     |> validate_provider()
-
+    |> validate_avatar_url()
     # |> validate_aka()
   end
 
@@ -60,6 +62,22 @@ defmodule LuaNox.Accounts.User do
       validate_required(changeset, [:aka])
     else
       changeset
+    end
+  end
+
+  def validate_avatar_url(changeset) do
+    case get_field(changeset, :avatar_url) do
+      nil ->
+        changeset
+
+      url when is_binary(url) ->
+        uri = URI.parse(url)
+
+        if uri.scheme == "https" and uri.host in @trusted_avatar_hosts do
+          changeset
+        else
+          add_error(changeset, :avatar_url, "must come from a trusted provider")
+        end
     end
   end
 

--- a/luanox/lib/luanox_web/components/navbar.ex
+++ b/luanox/lib/luanox_web/components/navbar.ex
@@ -54,7 +54,11 @@ defmodule LuaNoxWeb.NavBar do
           role="button"
           class="btn btn-ghost btn-block justify-start text-grey hover:text-primary rounded-field max-sm:px-1"
         >
-          <.icon name={:user_circle} type={:outline} />
+          <%= if @current_scope.user.avatar_url do %>
+            <img src={@current_scope.user.avatar_url} alt="" class="w-6 h-6 rounded-full" />
+          <% else %>
+            <.icon name={:user_circle} type={:outline} />
+          <% end %>
           <span class="mt-px">
             {User.unique_username(@current_scope.user) |> String.slice(0..20)}
           </span>

--- a/luanox/lib/luanox_web/components/navbar.ex
+++ b/luanox/lib/luanox_web/components/navbar.ex
@@ -22,7 +22,7 @@ defmodule LuaNoxWeb.NavBar do
           <span class="font-semibold">Luanox</span>
         </.link>
       </div>
-      
+
     <!-- Global menu items (always there no matters if mobile or desktop) -->
       <div class="flex items-center space-x-2 md:space-x-6">
         <LuaNoxWeb.Layouts.theme_toggle />
@@ -55,7 +55,7 @@ defmodule LuaNoxWeb.NavBar do
           class="btn btn-ghost btn-block justify-start text-grey hover:text-primary rounded-field max-sm:px-1"
         >
           <%= if @current_scope.user.avatar_url do %>
-            <img src={@current_scope.user.avatar_url} alt="" class="w-6 h-6 rounded-full" />
+            <img src={@current_scope.user.avatar_url} alt={User.unique_username(@current_scope.user)} class="w-6 h-6 rounded-full" />
           <% else %>
             <.icon name={:user_circle} type={:outline} />
           <% end %>

--- a/luanox/lib/luanox_web/components/package_box.ex
+++ b/luanox/lib/luanox_web/components/package_box.ex
@@ -16,7 +16,7 @@ defmodule LuaNoxWeb.PackageBox do
               {@name}
             </h2>
             <div class="bg-primary/10 text-primary border border-primary/20 px-2 py-1 text-xs font-mono">
-              {if @version, do: "v" <> @version, else: "—"}
+              {if @version, do: "v#{@version}", else: "—"}
             </div>
           </div>
 

--- a/luanox/lib/luanox_web/controllers/user_oauth.ex
+++ b/luanox/lib/luanox_web/controllers/user_oauth.ex
@@ -14,6 +14,8 @@ defmodule LuaNoxWeb.UserOauth do
   def callback(%{assigns: %{ueberauth_auth: %Ueberauth.Auth{} = auth}} = conn, _params) do
     case LuaNox.Accounts.get_user_by_auth(auth) do
       %LuaNox.Accounts.User{} = user ->
+        user = refresh_avatar(user, auth.info.image)
+
         conn
         |> LuaNoxWeb.UserAuth.log_in_user(user)
 
@@ -23,7 +25,8 @@ defmodule LuaNoxWeb.UserOauth do
           info: %{
             nickname: auth.info.nickname,
             name: auth.info.name,
-            email: auth.info.email
+            email: auth.info.email,
+            image: auth.info.image
           }
         }
 
@@ -67,7 +70,8 @@ defmodule LuaNoxWeb.UserOauth do
         info: %Ueberauth.Auth.Info{
           nickname: auth.info.nickname,
           name: auth.info.name,
-          email: email
+          email: email,
+          image: auth.info.image
         }
       }
 
@@ -90,4 +94,13 @@ defmodule LuaNoxWeb.UserOauth do
     |> put_flash(:error, "Missing required parameters. Please try authenticating again.")
     |> redirect(to: ~p"/login")
   end
+
+  defp refresh_avatar(user, image) when is_binary(image) do
+    case LuaNox.Accounts.update_user_avatar(user, image) do
+      {:ok, user} -> user
+      {:error, _changeset} -> user
+    end
+  end
+
+  defp refresh_avatar(user, _image), do: user
 end

--- a/luanox/lib/luanox_web/live/package_live/show.ex
+++ b/luanox/lib/luanox_web/live/package_live/show.ex
@@ -33,6 +33,6 @@ defmodule LuaNoxWeb.PackageLive.Show do
 
 defp latest_version([]), do: "-"
   defp latest_version(releases) do
-    "v" <> (releases |> List.last() |> Map.get(:version))
+    "v#{releases |> List.last() |> Map.get(:version)}"
   end
 end

--- a/luanox/lib/luanox_web/live/package_live/show.html.heex
+++ b/luanox/lib/luanox_web/live/package_live/show.html.heex
@@ -144,7 +144,7 @@
                 <%= if @package.user.avatar_url do %>
                 <img
                   src={@package.user.avatar_url}
-                  alt=""
+                  alt={@package.user.aka || @package.user.username}
                   class="w-10 h-10 lg:w-12 lg:h-12 rounded-full border border-base-300"
                 />
               <% else %>

--- a/luanox/lib/luanox_web/live/package_live/show.html.heex
+++ b/luanox/lib/luanox_web/live/package_live/show.html.heex
@@ -141,10 +141,17 @@
             </h3>
             <div class="space-y-3 lg:space-y-4">
               <div class="flex items-start gap-3">
-                <!-- Simple avatar placeholder -->
+                <%= if @package.user.avatar_url do %>
+                <img
+                  src={@package.user.avatar_url}
+                  alt=""
+                  class="w-10 h-10 lg:w-12 lg:h-12 rounded-full border border-base-300"
+                />
+              <% else %>
                 <div class="w-10 h-10 lg:w-12 lg:h-12 bg-primary/10 border rounded-full border-primary/20 flex items-center justify-center">
                   <.icon name={:user} type={:outline} class="w-5 h-5 lg:w-6 lg:h-6 text-primary" />
                 </div>
+              <% end %>
                 <div class="flex-1 min-w-0">
                   <div class="font-semibold text-sm lg:text-base text-base-content">
                     {@package.user.aka || @package.user.username}

--- a/luanox/lib/luanox_web/live/user_live/settings.ex
+++ b/luanox/lib/luanox_web/live/user_live/settings.ex
@@ -36,7 +36,7 @@ defmodule LuaNoxWeb.UserLive.Settings do
                 <%= if @current_scope.user.avatar_url do %>
                   <div class="avatar mb-4">
                     <div class="w-20 rounded-full">
-                      <img src={@current_scope.user.avatar_url} alt="" />
+                      <img src={@current_scope.user.avatar_url} alt={@current_scope.user.username} />
                     </div>
                   </div>
                 <% else %>

--- a/luanox/lib/luanox_web/live/user_live/settings.ex
+++ b/luanox/lib/luanox_web/live/user_live/settings.ex
@@ -33,13 +33,21 @@ defmodule LuaNoxWeb.UserLive.Settings do
           <div class="lg:col-span-1">
             <div class="bg-base-200 border border-base-300 rounded-box p-6 sticky top-6">
               <div class="text-center">
-                <div class="avatar avatar-placeholder mb-4">
-                  <div class="w-20 bg-primary/10 border-2 border-primary/20 rounded-full">
-                    <span class="text-3xl font-bold text-primary">
-                      {String.first(@current_scope.user.username)}
-                    </span>
+                <%= if @current_scope.user.avatar_url do %>
+                  <div class="avatar mb-4">
+                    <div class="w-20 rounded-full">
+                      <img src={@current_scope.user.avatar_url} alt="" />
+                    </div>
                   </div>
-                </div>
+                <% else %>
+                  <div class="avatar avatar-placeholder mb-4">
+                    <div class="w-20 bg-primary/10 border-2 border-primary/20 rounded-full">
+                      <span class="text-3xl font-bold text-primary">
+                        {String.first(@current_scope.user.username)}
+                      </span>
+                    </div>
+                  </div>
+                <% end %>
                 <h3 class="text-lg font-semibold text-base-content mb-1">
                   {@current_scope.user.username}
                 </h3>
@@ -196,9 +204,9 @@ defmodule LuaNoxWeb.UserLive.Settings do
                   </div>
                   <div class="divider"></div>
                   <div class="flex flex-col sm:flex-row justify-end gap-2">
-                    <button class="btn btn-neutral">
+                    <.link href={~p"/auth/github"} class="btn btn-neutral">
                       <.icon name={:refresh} type={:outline} class="w-4 h-4" /> Sync Profile
-                    </button>
+                    </.link>
                     <button
                       class="btn btn-error"
                       onclick="disable_account_modal.showModal()"

--- a/luanox/priv/repo/migrations/20260902204956_add_users_avatar_url.exs
+++ b/luanox/priv/repo/migrations/20260902204956_add_users_avatar_url.exs
@@ -1,0 +1,9 @@
+defmodule LuaNox.Repo.Migrations.AddUsersAvatarUrl do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :avatar_url, :string
+    end
+  end
+end

--- a/luanox/test/luanox/accounts_test.exs
+++ b/luanox/test/luanox/accounts_test.exs
@@ -112,4 +112,30 @@ defmodule LuaNox.AccountsTest do
       refute Accounts.get_user_by_session_token(token)
     end
   end
+
+  describe "register_user/1" do
+    test "stores the oauth avatar URL" do
+      auth = %Ueberauth.Auth{
+        provider: "github",
+        info: %Ueberauth.Auth.Info{
+          nickname: "ntb",
+          name: "NTBBloodbath",
+          email: unique_user_email(),
+          image: "https://avatars.githubusercontent.com/u/123456"
+        }
+      }
+
+      assert {:ok, %User{avatar_url: url}} = Accounts.register_user(auth)
+      assert url == "https://avatars.githubusercontent.com/u/123456"
+    end
+  end
+
+  describe "update_user_avatar/2" do
+    test "updates the avatar URL" do
+      user = user_fixture()
+
+      assert {:ok, %User{avatar_url: "https://example.com/new.png"}} =
+               Accounts.update_user_avatar(user, "https://example.com/new.png")
+    end
+  end
 end

--- a/luanox/test/luanox/accounts_test.exs
+++ b/luanox/test/luanox/accounts_test.exs
@@ -121,12 +121,27 @@ defmodule LuaNox.AccountsTest do
           nickname: "ntb",
           name: "NTBBloodbath",
           email: unique_user_email(),
-          image: "https://avatars.githubusercontent.com/u/123456"
+          image: "https://avatars.githubusercontent.com/u/36456999"
         }
       }
 
       assert {:ok, %User{avatar_url: url}} = Accounts.register_user(auth)
-      assert url == "https://avatars.githubusercontent.com/u/123456"
+      assert url == "https://avatars.githubusercontent.com/u/36456999"
+    end
+
+    test "rejects avatar URLs from untrusted hosts" do
+      auth = %Ueberauth.Auth{
+        provider: "github",
+        info: %Ueberauth.Auth.Info{
+          nickname: "ntb",
+          name: "NTBBloodbath",
+          email: unique_user_email(),
+          image: "https://evil.example/avatar.png"
+        }
+      }
+
+      assert {:error, %Ecto.Changeset{errors: errors}} = Accounts.register_user(auth)
+      assert {"must come from a trusted provider", _opts} = errors[:avatar_url]
     end
   end
 
@@ -134,8 +149,24 @@ defmodule LuaNox.AccountsTest do
     test "updates the avatar URL" do
       user = user_fixture()
 
-      assert {:ok, %User{avatar_url: "https://example.com/new.png"}} =
-               Accounts.update_user_avatar(user, "https://example.com/new.png")
+      assert {:ok, %User{avatar_url: "https://avatars.githubusercontent.com/u/36456999"}} =
+               Accounts.update_user_avatar(user, "https://avatars.githubusercontent.com/u/36456999")
+    end
+
+    test "rejects avatar URLs from untrusted hosts" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{errors: errors}} =
+               Accounts.update_user_avatar(user, "https://evil.example/avatar.png")
+
+      assert {"must come from a trusted provider", _opts} = errors[:avatar_url]
+    end
+
+    test "rejects non-https avatar URLs" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               Accounts.update_user_avatar(user, "http://avatars.githubusercontent.com/u/76052559")
     end
   end
 end


### PR DESCRIPTION
This pull request adds support for storing and displaying user avatar images fetched from OAuth providers (such as GitHub), and improves how user avatars are shown throughout the application. It includes backend changes to persist the avatar URL, updates to the OAuth flow to save and refresh avatars, and UI changes to display avatars where appropriate. Stacked on top of #124. Rebase merge. Do not squash.

**User Avatar Support**

* Added an `avatar_url` field to the `users` table and the `User` schema, along with an Ecto migration.
* Added tests to ensure the avatar URL is correctly stored and updated.

**UI Updates for Avatars**

* Modified the navigation bar, user settings page, and package details page to display the user's avatar image if available, falling back to a placeholder otherwise.
* Changed the un-wired "Sync Profile" button in user settings to a link that triggers OAuth re-authentication, allowing users to manually refresh their avatar.

**Minor Improvements**

* Updated version string formatting in package components for consistency.

**Practical notes**

* GitHub essentially always returns avatar_url from the API (it falls back to a Gravatar identicon URL), so the nil path is near-unreachable in practice. UNless we want other behavior and fallback to an empty button