### PR TITLE
feat(web): abbreviate large download counts

### DIFF
--- a/luanox/lib/luanox_web/components/core_components.ex
+++ b/luanox/lib/luanox_web/components/core_components.ex
@@ -531,4 +531,25 @@ defmodule LuaNoxWeb.CoreComponents do
     </footer>
     """
   end
+
+  def format_count(count) when is_integer(count) and count < 1_000, do: Integer.to_string(count)
+  def format_count(count) when is_integer(count) do
+    {unit, suffix} =
+      cond do
+        count >= 1_000_000_000 -> {1_000_000_000, "B"}
+        count >= 1_000_000 -> {1_000_000, "M"}
+        true -> {1_000, "K"}
+      end
+
+    text =
+      if rem(count, unit) == 0 do
+        Integer.to_string(div(count, unit))
+      else
+        :erlang.float_to_binary(count / unit, decimals: 1)
+        |> String.trim_trailing("0")
+        |> String.trim_trailing(".")
+      end
+
+    text <> suffix
+  end
 end

--- a/luanox/lib/luanox_web/components/package_box.ex
+++ b/luanox/lib/luanox_web/components/package_box.ex
@@ -27,7 +27,7 @@ defmodule LuaNoxWeb.PackageBox do
           <div class="flex items-center justify-between pt-3 border-t border-base-300">
             <div class="flex items-center space-x-2 text-xs text-base-content/70">
               <.icon name={:download} type={:outline} class="w-3 h-3" />
-              <span>{@download_count} downloads</span>
+              <span>{format_count(@download_count)} downloads</span>
             </div>
             <div class="text-xs text-primary group-hover:text-primary/80 transition-colors">
               View Details →
@@ -76,7 +76,7 @@ defmodule LuaNoxWeb.PackageBox do
             <% end %>
           </div>
         </div>
-        
+
     <!-- Most Recent Updates Section -->
         <div class="mb-16">
           <div class="text-center mb-12">
@@ -101,7 +101,7 @@ defmodule LuaNoxWeb.PackageBox do
             <% end %>
           </div>
         </div>
-        
+
     <!-- Call to Action -->
         <div class="text-center">
           <div class="bg-base-100 border border-base-300 py-16 px-8">

--- a/luanox/lib/luanox_web/live/package_live/show.html.heex
+++ b/luanox/lib/luanox_web/live/package_live/show.html.heex
@@ -86,7 +86,7 @@
                   </div>
                   <div class="flex items-center justify-between sm:justify-end gap-3 sm:gap-4">
                     <span class="text-sm text-base-content/70">
-                      {release.download_count} downloads
+                      {format_count(release.download_count)} downloads
                     </span>
                     <.link
                       href={~p"/api/download/#{@package.name}/#{to_string(release.version)}"}
@@ -116,7 +116,7 @@
               <div class="flex justify-between items-center">
                 <span class="text-sm lg:text-base text-base-content/70">Total Downloads</span>
                 <span class="font-semibold text-base lg:text-lg text-base-content">
-                  {Enum.sum(for r <- @package.releases, do: r.download_count)}
+                  {format_count(Enum.sum(for r <- @package.releases, do: r.download_count))}
                 </span>
               </div>
               <div class="flex justify-between items-center">


### PR DESCRIPTION
Add a hand-rolled format_count/1 to CoreComponents that draws counts over 1000 with K/M/B suffixes (1.5K, 2.1M, 1B) and keeps everything below 1000 raw. Apply it to download counts on the landing page and package index cards as well as per-release and total counts on the package show page.

Resolves #58

---

<details>
<summary>Demo</summary>

<img width="1183" height="1214" alt="image" src="https://github.com/user-attachments/assets/6aacfc15-6250-4b29-a430-9ffab73cab77" />

</details>