### PR TITLE
feat(web): add custom error pages and in-page not-found states

### DIFF
--- a/luanox/lib/luanox_web/components/not_found.ex
+++ b/luanox/lib/luanox_web/components/not_found.ex
@@ -1,0 +1,34 @@
+defmodule LuaNoxWeb.Components.NotFound do
+  use LuaNoxWeb, :html
+
+  attr(:title, :string, required: true)
+  attr(:message, :string, required: true)
+
+  def not_found(assigns) do
+    ~H"""
+    <div class="flex items-center justify-center max-w-6xl h-[calc(100vh-116px)] md:h-[calc(100vh-124px)] mx-auto px-6 md:px-4 lg:px-8 py-16 lg:py-24">
+      <div class="bg-base-200 border border-base-300 rounded-box p-12 text-center max-w-xl mx-auto">
+        <.icon
+          name={:help_circle}
+          type={:outline}
+          class="w-14 h-14 lg:w-16 lg:h-16 text-primary mx-auto mb-4"
+        />
+        <h1 class="text-xl lg:text-2xl font-semibold text-base-content mb-2">
+          {@title}
+        </h1>
+        <p class="text-base-content/70 mb-6">
+          {@message}
+        </p>
+        <div class="flex flex-col sm:flex-row justify-center gap-2">
+          <.link navigate={~p"/packages"} class="btn btn-primary">
+            Browse packages
+          </.link>
+          <.link navigate={~p"/"} class="btn btn-neutral">
+            Back to home
+          </.link>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/luanox/lib/luanox_web/controllers/error_html.ex
+++ b/luanox/lib/luanox_web/controllers/error_html.ex
@@ -1,0 +1,9 @@
+defmodule LuaNoxWeb.ErrorHTML do
+  use LuaNoxWeb, :html
+
+  embed_templates "error_html/*"
+
+  def render(template, _assigns) do
+    Phoenix.Controller.status_message_from_template(template)
+  end
+end

--- a/luanox/lib/luanox_web/controllers/error_html/404.html.heex
+++ b/luanox/lib/luanox_web/controllers/error_html/404.html.heex
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/assets/css/app.css" />
+    <title>Not Found - Luanox</title>
+  </head>
+  <body class="bg-base-100 antialiased">
+    <div class="min-h-screen flex flex-col items-center justify-center px-4 text-center">
+      <img src="/images/logo.svg" alt="Luanox logo" class="h-10 w-auto mb-8" />
+      <div class="text-6xl font-bold text-base-content mb-3">404</div>
+      <p class="text-base-content/70 mb-8">The page you are looking for does not exist.</p>
+      <a href="/" class="btn btn-primary">Back to home</a>
+    </div>
+  </body>
+</html>

--- a/luanox/lib/luanox_web/controllers/error_html/500.html.heex
+++ b/luanox/lib/luanox_web/controllers/error_html/500.html.heex
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/assets/css/app.css" />
+    <title>Something went wrong - Luanox</title>
+  </head>
+  <body class="bg-base-100 antialiased">
+    <div class="min-h-screen flex flex-col items-center justify-center px-4 text-center">
+      <img src="/images/logo.svg" alt="Luanox logo" class="h-10 w-auto mb-8" />
+      <div class="text-6xl font-bold text-base-content mb-3">500</div>
+      <p class="text-base-content/70 mb-8">
+        Something went wrong on our end. Please try again later.
+      </p>
+      <a href="/" class="btn btn-primary">Back to home</a>
+    </div>
+  </body>
+</html>

--- a/luanox/lib/luanox_web/live/package_live/show.ex
+++ b/luanox/lib/luanox_web/live/package_live/show.ex
@@ -1,6 +1,8 @@
 defmodule LuaNoxWeb.PackageLive.Show do
   alias LuaNox.Packages
   use LuaNoxWeb, :live_view
+
+  import LuaNoxWeb.Components.NotFound
   import LuaNoxWeb.Markdown, only: [markdown: 1]
 
   def mount(%{"name" => name}, _session, socket) do
@@ -8,12 +10,13 @@ defmodule LuaNoxWeb.PackageLive.Show do
       nil ->
         {:ok,
          socket
-         |> put_flash(:error, "Package not found")
-         |> redirect(to: ~p"/packages")}
+         |> assign(:not_found, true)
+         |> assign(:page_title, "Package not found")}
 
       package ->
         {:ok,
          socket
+         |> assign(:not_found, false)
          |> assign(:package, package |> LuaNox.Repo.preload(:user))
          |> assign(:page_title, package.name)}
     end

--- a/luanox/lib/luanox_web/live/package_live/show.html.heex
+++ b/luanox/lib/luanox_web/live/package_live/show.html.heex
@@ -1,5 +1,11 @@
 <Layouts.app flash={@flash} current_scope={@current_scope}>
-  <div class="min-h-screen bg-base-100">
+  <%= if @not_found do %>
+    <.not_found
+      title="Package not found"
+      message="The package you are looking for does not exist or was removed."
+    />
+  <% else %>
+    <div class="min-h-screen bg-base-100">
     <div class="bg-base-200 border-b border-base-300">
       <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 lg:py-8">
         <div class="mb-4 lg:mb-6">
@@ -203,5 +209,6 @@
         </div>
       </div>
     </div>
-  </div>
+    </div>
+  <% end %>
 </Layouts.app>

--- a/luanox/lib/luanox_web/live/user_live/profile.ex
+++ b/luanox/lib/luanox_web/live/user_live/profile.ex
@@ -3,6 +3,7 @@ defmodule LuaNoxWeb.UserLive.Profile do
   alias LuaNox.Packages
   use LuaNoxWeb, :live_view
 
+  import LuaNoxWeb.Components.NotFound
   import LuaNoxWeb.PackageBox
 
   def mount(%{"username" => username}, _session, socket) do
@@ -10,15 +11,20 @@ defmodule LuaNoxWeb.UserLive.Profile do
       nil ->
         {:ok,
          socket
-         |> put_flash(:error, "User not found")
-         |> redirect(to: ~p"/")}
+         |> assign(:not_found, true)
+         |> assign(:page_title, "User not found")}
 
       user ->
         {:ok,
          socket
+         |> assign(:not_found, false)
          |> assign(:user, user)
          |> assign(:page_title, user.aka || user.username)}
     end
+  end
+
+  def handle_params(_params, _url, %{assigns: %{not_found: true}} = socket) do
+    {:noreply, socket}
   end
 
   def handle_params(params, _url, socket) do

--- a/luanox/lib/luanox_web/live/user_live/profile.html.heex
+++ b/luanox/lib/luanox_web/live/user_live/profile.html.heex
@@ -1,5 +1,11 @@
 <Layouts.app flash={@flash} current_scope={@current_scope}>
-  <div class="bg-base-100 border-b border-base-300">
+  <%= if @not_found do %>
+    <.not_found
+      title="User not found"
+      message="The user you are looking for does not exist."
+    />
+  <% else %>
+    <div class="bg-base-100 border-b border-base-300">
     <div class="max-w-6xl mx-auto px-4 md:px-6 lg:px-8 py-6 lg:py-8">
       <div class="flex flex-wrap flex-row items-center gap-4 lg:gap-6">
         <%= if @user.avatar_url do %>
@@ -121,5 +127,6 @@
         <% end %>
       </div>
     <% end %>
-  </div>
+    </div>
+  <% end %>
 </Layouts.app>

--- a/luanox/test/luanox_web/controllers/error_html_test.exs
+++ b/luanox/test/luanox_web/controllers/error_html_test.exs
@@ -1,5 +1,15 @@
 defmodule LuaNoxWeb.ErrorHTMLTest do
   use LuaNoxWeb.ConnCase, async: true
 
-  # ErrorHTML module is empty - tests removed as the module has no render functions
+  test "renders the 404 page", %{conn: conn} do
+    conn = get(conn, "/nonexistent")
+
+    assert html_response(conn, 404) =~ "does not exist"
+  end
+
+  test "renders the 500 template" do
+    rendered = apply(LuaNoxWeb.ErrorHTML, :"500", [%{}])
+
+    assert rendered.static |> Enum.join() =~ "Something went wrong"
+  end
 end

--- a/luanox/test/luanox_web/live/package_live/show_test.exs
+++ b/luanox/test/luanox_web/live/package_live/show_test.exs
@@ -1,0 +1,11 @@
+defmodule LuaNoxWeb.PackageLive.ShowTest do
+  use LuaNoxWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  test "renders not found for an unknown package", %{conn: conn} do
+    {:ok, _lv, html} = live(conn, ~p"/package/does-not-exist")
+
+    assert html =~ "Package not found"
+  end
+end

--- a/luanox/test/luanox_web/live/user_live/profile_test.exs
+++ b/luanox/test/luanox_web/live/user_live/profile_test.exs
@@ -59,12 +59,10 @@ defmodule LuaNoxWeb.UserLive.ProfileTest do
       assert html =~ "lux CLI"
     end
 
-    test "redirects home for an unknown user", %{conn: conn} do
-      {:error, redirect} = live(conn, ~p"/users/does-not-exist")
+    test "renders not found for an unknown user", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/users/does-not-exist")
 
-      assert {:redirect, %{to: to, flash: flash}} = redirect
-      assert to == ~p"/"
-      assert %{"error" => "User not found"} = flash
+      assert html =~ "User not found"
     end
 
     test "paginates the user's packages", %{conn: conn} do


### PR DESCRIPTION
Replace the empty error_html module and soft-404 redirects with real pages. Add branded 404/500 templates wired through embed_templates, and a shared NotFound component rendered in-place when an unknown package or user is requested, dropping the previous flash-and-redirect behavior. Delete the unused error_test_controller scaffold. Tests cover the 404 response, the 500 template, and both not-found live views.

Closes #138 